### PR TITLE
fix(deps): patch open Dependabot alerts (rand, fast-uri, lodash)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,9 +636,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha",
  "rand_core",

--- a/package-lock.json
+++ b/package-lock.json
@@ -324,9 +324,9 @@
       "license": "MIT"
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -542,7 +542,6 @@
       "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "import-fresh": "^3.3.0",
         "js-yaml": "^4.1.0",
@@ -716,9 +715,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -1159,9 +1158,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -2005,7 +2004,8 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
       "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,11 @@
     "@commitlint/cli": "^18.0.0",
     "@commitlint/config-conventional": "^18.0.0"
   },
+  "overrides": {
+    "ajv": ">=8.18.0",
+    "fast-uri": ">=3.1.2",
+    "lodash": ">=4.18.0"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/elioetibr/rust-yaml.git"


### PR DESCRIPTION
## Summary

Closes the six open Dependabot alerts on this repo. All fixes are transitive lockfile bumps — no direct-dependency or API changes.

| Pkg | From → To | Advisory | Severity | Scope |
|---|---|---|---|---|
| `rand` | 0.9.2 → 0.9.3 | RUSTSEC-2026-0097 / GHSA-cq8v-f236-94qc | low | rust runtime |
| `fast-uri` | 3.0.6 → 3.1.2 | CVE-2026-6321 (path traversal) + CVE-2026-6322 (host confusion) | high × 2 | npm dev (commitlint → ajv) |
| `lodash` | 4.17.21 → 4.18.1 | CVE-2025-13465 + CVE-2026-2950 (prototype pollution) + CVE-2026-4800 (_.template code injection) | medium × 2, high × 1 | npm dev (commitlint) |

Also pins `ajv ≥ 8.18.0` via `package.json` `overrides` so `npm audit` reports zero issues going forward (the corresponding alert was already auto-dismissed by Dependabot because commitlint doesn't pass `$data: true` — pin is hygienic).

The npm fixes are dev-only: the published crate ships no JavaScript, so end-users were never exposed.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo test --lib` — 138 / 138 passing on main-base
- [x] `npm audit` — `found 0 vulnerabilities`
- [ ] CI green
- [ ] Dependabot auto-closes the six alerts once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)