### PR TITLE
fix(v1.0.1): untrusted-input hardening — close all P0 hotfix issues

### DIFF
--- a/benches/advanced_features.rs
+++ b/benches/advanced_features.rs
@@ -286,6 +286,7 @@ fn bench_memory_usage(c: &mut Criterion) {
                             max_alias_depth: 100,
                             max_collection_size: 100000,
                             max_complexity_score: 1_000_000,
+                            max_total_alias_nodes: 1_000_000,
                             timeout: None,
                         },
                         ..Default::default()

--- a/src/composer.rs
+++ b/src/composer.rs
@@ -11,53 +11,62 @@ use crate::{
 use indexmap::IndexMap;
 use std::collections::HashMap;
 
-/// Calculate complexity score for a value (for resource limiting)
-fn calculate_value_complexity(value: &Value) -> Result<usize> {
-    let mut complexity = 1usize;
-
-    match value {
-        Value::Sequence(seq) => {
-            complexity = complexity.saturating_add(seq.len());
-            for item in seq {
-                complexity = complexity.saturating_add(calculate_value_complexity(item)?);
+/// Calculate complexity score for a value (for resource limiting).
+///
+/// Iterative on purpose: pathological documents can produce arbitrarily
+/// deep `Value` trees (e.g. via anchors), and a recursive implementation
+/// stack-overflows long before any in-process limit fires (#16).
+pub(crate) fn calculate_value_complexity(value: &Value) -> Result<usize> {
+    let mut total: usize = 0;
+    let mut stack: Vec<&Value> = vec![value];
+    while let Some(node) = stack.pop() {
+        match node {
+            Value::Sequence(seq) => {
+                total = total.saturating_add(1usize.saturating_add(seq.len()));
+                for item in seq {
+                    stack.push(item);
+                }
             }
-        }
-        Value::Mapping(map) => {
-            complexity = complexity.saturating_add(map.len().saturating_mul(2));
-            for (key, val) in map {
-                complexity = complexity.saturating_add(calculate_value_complexity(key)?);
-                complexity = complexity.saturating_add(calculate_value_complexity(val)?);
+            Value::Mapping(map) => {
+                total = total.saturating_add(1usize.saturating_add(map.len().saturating_mul(2)));
+                for (k, v) in map {
+                    stack.push(k);
+                    stack.push(v);
+                }
             }
+            _ => total = total.saturating_add(1),
         }
-        _ => {} // Scalars have complexity 1
     }
-
-    Ok(complexity)
+    Ok(total)
 }
 
-/// Calculate the maximum nesting depth of a value structure
+/// Calculate the maximum nesting depth of a value structure.
+///
+/// Iterative DFS with an explicit work-list, for the same stack-safety
+/// reason as [`calculate_value_complexity`] (#16).
 fn calculate_structure_depth(value: &Value) -> usize {
-    match value {
-        Value::Sequence(seq) => {
-            if seq.is_empty() {
-                1
-            } else {
-                1 + seq.iter().map(calculate_structure_depth).max().unwrap_or(0)
-            }
+    let mut max_depth: usize = 1;
+    let mut stack: Vec<(&Value, usize)> = vec![(value, 1)];
+    while let Some((node, depth)) = stack.pop() {
+        if depth > max_depth {
+            max_depth = depth;
         }
-        Value::Mapping(map) => {
-            if map.is_empty() {
-                1
-            } else {
-                1 + map
-                    .values()
-                    .map(calculate_structure_depth)
-                    .max()
-                    .unwrap_or(0)
+        let next = depth.saturating_add(1);
+        match node {
+            Value::Sequence(seq) => {
+                for item in seq {
+                    stack.push((item, next));
+                }
             }
+            Value::Mapping(map) => {
+                for (_, v) in map {
+                    stack.push((v, next));
+                }
+            }
+            _ => {}
         }
-        _ => 1, // Scalars have depth 1
     }
+    max_depth
 }
 
 /// Trait for YAML composers that convert event streams to node structures
@@ -274,9 +283,14 @@ impl BasicComposer {
                             ));
                         }
 
-                        // Add complexity score for alias expansion
+                        let nodes = calculate_value_complexity(value)?;
+                        // Cap cumulative alias materialization BEFORE the
+                        // clone — closes the billion-laughs gap where wide
+                        // fan-out allocates millions of nodes before
+                        // max_complexity_score fires (#15).
                         self.resource_tracker
-                            .add_complexity(&self.limits, calculate_value_complexity(value)?)?;
+                            .add_alias_materialization(&self.limits, nodes)?;
+                        self.resource_tracker.add_complexity(&self.limits, nodes)?;
                         Ok(Some(value.clone()))
                     }
                     None => Err(Error::construction(
@@ -555,6 +569,56 @@ impl Default for BasicComposer {
 mod tests {
     use super::*;
     use indexmap::IndexMap;
+
+    /// Build a sequence-of-sequence chain `depth` levels deep without using
+    /// the parser, so we can stress the complexity/depth helpers past any
+    /// `max_depth` the parser would normally enforce.
+    fn build_deep_sequence(depth: usize) -> Value {
+        let mut v = Value::Int(1);
+        for _ in 0..depth {
+            v = Value::Sequence(vec![v]);
+        }
+        v
+    }
+
+    /// Tear down a deep Value iteratively so the test's cleanup phase
+    /// doesn't stack-overflow inside `Value::drop` / `Vec::drop`.
+    /// This is only needed because `Value`'s default `Drop` is recursive.
+    fn drop_deep(mut v: Value) {
+        let mut stack: Vec<Value> = Vec::new();
+        stack.push(std::mem::replace(&mut v, Value::Null));
+        while let Some(node) = stack.pop() {
+            if let Value::Sequence(seq) = node {
+                for item in seq {
+                    stack.push(item);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn iterative_complexity_handles_100k_deep_value() {
+        // Regression for #16: a recursive implementation would
+        // stack-overflow long before reaching this depth (Rust's default
+        // 8 MB stack at ~120 bytes/frame ≈ 65 k frames). The iterative
+        // implementation must return a sane count without panicking.
+        let deep = build_deep_sequence(100_000);
+        let complexity = calculate_value_complexity(&deep).expect("must not error");
+        // Each Sequence contributes 1 (self) + 1 (len), plus the inner
+        // scalar contributes 1. So 100_000 * 2 + 1 = 200_001.
+        assert_eq!(complexity, 200_001);
+        drop_deep(deep);
+    }
+
+    #[test]
+    fn iterative_structure_depth_handles_100k_deep_value() {
+        // Same regression for calculate_structure_depth (#16).
+        let deep = build_deep_sequence(100_000);
+        let depth = calculate_structure_depth(&deep);
+        // 100_000 wrapping sequences + the inner scalar leaf = 100_001.
+        assert_eq!(depth, 100_001);
+        drop_deep(deep);
+    }
 
     #[test]
     fn test_check_document() {

--- a/src/composer_borrowed.rs
+++ b/src/composer_borrowed.rs
@@ -451,4 +451,180 @@ mod tests {
             panic!("Expected mapping");
         }
     }
+
+    // ---- iterative helpers (#16) ----
+
+    #[test]
+    fn borrowed_structure_depth_scalar_is_one() {
+        assert_eq!(calculate_borrowed_structure_depth(&BorrowedValue::Null), 1);
+        assert_eq!(
+            calculate_borrowed_structure_depth(&BorrowedValue::Int(7)),
+            1
+        );
+        assert_eq!(
+            calculate_borrowed_structure_depth(&BorrowedValue::owned_string("x".into())),
+            1
+        );
+    }
+
+    #[test]
+    fn borrowed_structure_depth_empty_collections_is_one() {
+        assert_eq!(
+            calculate_borrowed_structure_depth(&BorrowedValue::Sequence(Vec::new())),
+            1
+        );
+        assert_eq!(
+            calculate_borrowed_structure_depth(&BorrowedValue::Mapping(IndexMap::new())),
+            1
+        );
+    }
+
+    #[test]
+    fn borrowed_structure_depth_nested_sequence() {
+        // [[[1]]] → depth 4 (outer seq + 2 nested seqs + scalar)
+        let inner = BorrowedValue::Sequence(vec![BorrowedValue::Int(1)]);
+        let mid = BorrowedValue::Sequence(vec![inner]);
+        let outer = BorrowedValue::Sequence(vec![mid]);
+        assert_eq!(calculate_borrowed_structure_depth(&outer), 4);
+    }
+
+    #[test]
+    fn borrowed_structure_depth_nested_mapping() {
+        // { k: { k: 1 } } → depth 3
+        let mut inner = IndexMap::new();
+        inner.insert(
+            BorrowedValue::owned_string("k".into()),
+            BorrowedValue::Int(1),
+        );
+        let mut outer = IndexMap::new();
+        outer.insert(
+            BorrowedValue::owned_string("k".into()),
+            BorrowedValue::Mapping(inner),
+        );
+        assert_eq!(
+            calculate_borrowed_structure_depth(&BorrowedValue::Mapping(outer)),
+            3
+        );
+    }
+
+    #[test]
+    fn borrowed_complexity_scalar_is_one() {
+        assert_eq!(calculate_borrowed_complexity(&BorrowedValue::Null), 1);
+        assert_eq!(calculate_borrowed_complexity(&BorrowedValue::Bool(true)), 1);
+        assert_eq!(calculate_borrowed_complexity(&BorrowedValue::Int(42)), 1);
+        assert_eq!(
+            calculate_borrowed_complexity(&BorrowedValue::owned_string("hi".into())),
+            1
+        );
+    }
+
+    #[test]
+    fn borrowed_complexity_sequence_charges_len_plus_one_plus_children() {
+        // Sequence with 3 scalar children: 1 (seq) + 3 (len) + 3*1 (children) = 7
+        let seq = BorrowedValue::Sequence(vec![
+            BorrowedValue::Int(1),
+            BorrowedValue::Int(2),
+            BorrowedValue::Int(3),
+        ]);
+        assert_eq!(calculate_borrowed_complexity(&seq), 7);
+    }
+
+    #[test]
+    fn borrowed_complexity_mapping_charges_two_per_entry_plus_one_plus_children() {
+        // Mapping with 2 entries (k1: v1, k2: v2): 1 + 2*2 + 4*1 = 9
+        let mut map = IndexMap::new();
+        map.insert(
+            BorrowedValue::owned_string("k1".into()),
+            BorrowedValue::Int(1),
+        );
+        map.insert(
+            BorrowedValue::owned_string("k2".into()),
+            BorrowedValue::Int(2),
+        );
+        assert_eq!(
+            calculate_borrowed_complexity(&BorrowedValue::Mapping(map)),
+            9
+        );
+    }
+
+    #[test]
+    fn borrowed_structure_depth_is_stack_safe_for_deep_input() {
+        // 100k-deep sequence would blow the stack if the helper were recursive.
+        let mut v = BorrowedValue::Int(0);
+        for _ in 0..100_000 {
+            v = BorrowedValue::Sequence(vec![v]);
+        }
+        // We don't care about the exact value, only that it doesn't overflow.
+        let depth = calculate_borrowed_structure_depth(&v);
+        assert!(depth >= 100_000);
+        // Iterative drop to avoid the recursive Drop in Vec/IndexMap.
+        drop_borrowed_iteratively(v);
+    }
+
+    #[test]
+    fn borrowed_complexity_is_stack_safe_for_deep_input() {
+        let mut v = BorrowedValue::Int(0);
+        for _ in 0..100_000 {
+            v = BorrowedValue::Sequence(vec![v]);
+        }
+        let _ = calculate_borrowed_complexity(&v);
+        drop_borrowed_iteratively(v);
+    }
+
+    // Drops a deeply nested BorrowedValue without recursing through
+    // Vec/IndexMap's own Drop. Used only by the stack-safety tests above.
+    fn drop_borrowed_iteratively(root: BorrowedValue<'_>) {
+        let mut stack: Vec<BorrowedValue<'_>> = vec![root];
+        while let Some(node) = stack.pop() {
+            match node {
+                BorrowedValue::Sequence(seq) => stack.extend(seq),
+                BorrowedValue::Mapping(map) => {
+                    for (k, v) in map {
+                        stack.push(k);
+                        stack.push(v);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    // ---- alias materialization cap (#15) on ZeroCopyComposer ----
+
+    fn permissive_with_alias_cap(cap: usize) -> Limits {
+        Limits {
+            max_total_alias_nodes: cap,
+            ..Limits::permissive()
+        }
+    }
+
+    #[test]
+    fn zero_copy_alias_materialization_cap_fires() {
+        // Anchor expands to a 10-element sequence; 20 aliased siblings.
+        // Each *a materialization charges ~11 nodes, so cap=50 must reject.
+        let input = r#"
+a: &a [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+b: [*a, *a, *a, *a, *a, *a, *a, *a, *a, *a, *a, *a, *a, *a, *a, *a, *a, *a, *a, *a]
+"#;
+        let mut composer = ZeroCopyComposer::with_limits(input, permissive_with_alias_cap(50));
+        let err = composer.compose_document().expect_err("cap should reject");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("alias") || msg.contains("materializ") || msg.contains("limit"),
+            "expected materialization-cap error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn zero_copy_alias_below_cap_succeeds() {
+        // Same shape but a generous cap → must succeed.
+        let input = r#"
+a: &a [1, 2, 3]
+b: [*a, *a]
+"#;
+        let mut composer = ZeroCopyComposer::with_limits(input, permissive_with_alias_cap(10_000));
+        let result = composer.compose_document().unwrap().unwrap();
+        // sanity: returns a mapping
+        assert!(matches!(result, BorrowedValue::Mapping(_)));
+    }
 }

--- a/src/composer_borrowed.rs
+++ b/src/composer_borrowed.rs
@@ -12,32 +12,56 @@ use indexmap::IndexMap;
 use std::collections::HashMap;
 
 /// Calculate the maximum nesting depth of a borrowed value structure
+/// Iterative DFS — see [`crate::composer::calculate_structure_depth`] (#16).
 fn calculate_borrowed_structure_depth(value: &BorrowedValue) -> usize {
-    match value {
-        BorrowedValue::Sequence(seq) => {
-            if seq.is_empty() {
-                1
-            } else {
-                1 + seq
-                    .iter()
-                    .map(calculate_borrowed_structure_depth)
-                    .max()
-                    .unwrap_or(0)
-            }
+    let mut max_depth: usize = 1;
+    let mut stack: Vec<(&BorrowedValue, usize)> = vec![(value, 1)];
+    while let Some((node, depth)) = stack.pop() {
+        if depth > max_depth {
+            max_depth = depth;
         }
-        BorrowedValue::Mapping(map) => {
-            if map.is_empty() {
-                1
-            } else {
-                1 + map
-                    .values()
-                    .map(calculate_borrowed_structure_depth)
-                    .max()
-                    .unwrap_or(0)
+        let next = depth.saturating_add(1);
+        match node {
+            BorrowedValue::Sequence(seq) => {
+                for item in seq {
+                    stack.push((item, next));
+                }
             }
+            BorrowedValue::Mapping(map) => {
+                for (_, v) in map {
+                    stack.push((v, next));
+                }
+            }
+            _ => {}
         }
-        _ => 1, // Scalars have depth 1
     }
+    max_depth
+}
+
+/// Cost of materialising a borrowed value, used to charge alias expansion
+/// against `max_total_alias_nodes` (#15). Iterative for stack safety (#16).
+fn calculate_borrowed_complexity(value: &BorrowedValue) -> usize {
+    let mut total: usize = 0;
+    let mut stack: Vec<&BorrowedValue> = vec![value];
+    while let Some(node) = stack.pop() {
+        match node {
+            BorrowedValue::Sequence(seq) => {
+                total = total.saturating_add(1usize.saturating_add(seq.len()));
+                for item in seq {
+                    stack.push(item);
+                }
+            }
+            BorrowedValue::Mapping(map) => {
+                total = total.saturating_add(1usize.saturating_add(map.len().saturating_mul(2)));
+                for (k, v) in map {
+                    stack.push(k);
+                    stack.push(v);
+                }
+            }
+            _ => total = total.saturating_add(1),
+        }
+    }
+    total
 }
 
 /// Trait for zero-copy YAML composers
@@ -200,7 +224,12 @@ impl<'a> ZeroCopyComposer<'a> {
                             ));
                         }
 
-                        // Only clone if we absolutely need to
+                        // Cap cumulative alias materialization BEFORE
+                        // committing the clone (#15 billion-laughs gap).
+                        let nodes = calculate_borrowed_complexity(value);
+                        self.resource_tracker
+                            .add_alias_materialization(&self.limits, nodes)?;
+                        self.resource_tracker.add_complexity(&self.limits, nodes)?;
                         Ok(Some(value.clone_if_needed()))
                     }
                     None => Err(Error::construction(

--- a/src/composer_comments.rs
+++ b/src/composer_comments.rs
@@ -2,7 +2,8 @@
 
 use crate::{
     BasicParser, BasicScanner, CommentedValue, Comments, Error, Limits, Parser, Position,
-    ResourceTracker, Result, Scanner, Style, TokenType, Value, parser::EventType,
+    ResourceTracker, Result, Scanner, Style, TokenType, Value,
+    composer::calculate_value_complexity, parser::EventType,
 };
 use indexmap::IndexMap;
 use std::collections::HashMap;
@@ -325,10 +326,30 @@ impl CommentPreservingComposer {
             ));
         }
 
+        // Cap alias expansion depth (parity with BasicComposer).
+        if self.alias_expansion_stack.len() >= self.limits.max_alias_depth {
+            return Err(Error::parse(
+                position,
+                format!(
+                    "Maximum alias expansion depth {} exceeded",
+                    self.limits.max_alias_depth
+                ),
+            ));
+        }
+
         self.alias_expansion_stack.push(anchor.clone());
 
         let result = match self.anchors.get(&anchor) {
-            Some(value) => Ok(Some(value.clone())),
+            Some(value) => {
+                // Cap cumulative alias materialization BEFORE the clone —
+                // closes the billion-laughs gap on the comment-preserving
+                // load path (#15).
+                let nodes = calculate_value_complexity(&value.value)?;
+                self.resource_tracker
+                    .add_alias_materialization(&self.limits, nodes)?;
+                self.resource_tracker.add_complexity(&self.limits, nodes)?;
+                Ok(Some(value.clone()))
+            }
             None => Err(Error::parse(
                 position,
                 format!("Unknown anchor '{}'", anchor),

--- a/src/composer_optimized.rs
+++ b/src/composer_optimized.rs
@@ -485,4 +485,107 @@ ref2: *base
         // The anchors should use Rc, so cloning should be cheap
         assert!(composer.anchors.len() > 0);
     }
+
+    // ---- iterative helpers (#16) ----
+
+    #[test]
+    fn optimized_structure_depth_scalar_and_empty_is_one() {
+        assert_eq!(
+            calculate_optimized_structure_depth(&OptimizedValue::Null),
+            1
+        );
+        assert_eq!(
+            calculate_optimized_structure_depth(&OptimizedValue::Int(7)),
+            1
+        );
+        assert_eq!(
+            calculate_optimized_structure_depth(&OptimizedValue::Sequence(Rc::new(Vec::new()))),
+            1
+        );
+        assert_eq!(
+            calculate_optimized_structure_depth(&OptimizedValue::Mapping(Rc::new(IndexMap::new()))),
+            1
+        );
+    }
+
+    #[test]
+    fn optimized_structure_depth_nested_sequence() {
+        // [[[1]]] → depth 4
+        let inner = OptimizedValue::Sequence(Rc::new(vec![OptimizedValue::Int(1)]));
+        let mid = OptimizedValue::Sequence(Rc::new(vec![inner]));
+        let outer = OptimizedValue::Sequence(Rc::new(vec![mid]));
+        assert_eq!(calculate_optimized_structure_depth(&outer), 4);
+    }
+
+    #[test]
+    fn optimized_complexity_scalar_is_one() {
+        assert_eq!(calculate_complexity(&OptimizedValue::Null).unwrap(), 1);
+        assert_eq!(calculate_complexity(&OptimizedValue::Int(42)).unwrap(), 1);
+    }
+
+    #[test]
+    fn optimized_complexity_sequence_charges_len_plus_one_plus_children() {
+        // [1, 2, 3] → 1 + 3 + 3*1 = 7
+        let seq = OptimizedValue::Sequence(Rc::new(vec![
+            OptimizedValue::Int(1),
+            OptimizedValue::Int(2),
+            OptimizedValue::Int(3),
+        ]));
+        assert_eq!(calculate_complexity(&seq).unwrap(), 7);
+    }
+
+    #[test]
+    fn optimized_complexity_mapping_charges_two_per_entry_plus_one_plus_children() {
+        // { k1:1, k2:2 } → 1 + 2*2 + 4*1 = 9
+        let mut map = IndexMap::new();
+        map.insert(
+            OptimizedValue::String(Rc::new("k1".to_string())),
+            OptimizedValue::Int(1),
+        );
+        map.insert(
+            OptimizedValue::String(Rc::new("k2".to_string())),
+            OptimizedValue::Int(2),
+        );
+        assert_eq!(
+            calculate_complexity(&OptimizedValue::Mapping(Rc::new(map))).unwrap(),
+            9
+        );
+    }
+
+    // ---- alias materialization cap (#15) on ReducedAllocComposer ----
+
+    fn permissive_with_alias_cap(cap: usize) -> Limits {
+        Limits {
+            max_total_alias_nodes: cap,
+            ..Limits::permissive()
+        }
+    }
+
+    #[test]
+    fn optimized_alias_materialization_cap_fires() {
+        let input = r#"
+a: &a [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+b: [*a, *a, *a, *a, *a, *a, *a, *a, *a, *a, *a, *a, *a, *a, *a, *a, *a, *a, *a, *a]
+"#;
+        let mut composer =
+            ReducedAllocComposer::with_limits(input.to_string(), permissive_with_alias_cap(50));
+        let err = composer.compose_document().expect_err("cap should reject");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("alias") || msg.contains("materializ") || msg.contains("limit"),
+            "expected materialization-cap error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn optimized_alias_below_cap_succeeds() {
+        let input = r#"
+a: &a [1, 2, 3]
+b: [*a, *a]
+"#;
+        let mut composer =
+            ReducedAllocComposer::with_limits(input.to_string(), permissive_with_alias_cap(10_000));
+        let result = composer.compose_document().unwrap().unwrap();
+        assert!(matches!(result, OptimizedValue::Mapping(_)));
+    }
 }

--- a/src/composer_optimized.rs
+++ b/src/composer_optimized.rs
@@ -12,33 +12,30 @@ use indexmap::IndexMap;
 use std::collections::HashMap;
 use std::rc::Rc;
 
-/// Calculate the maximum nesting depth of an optimized value structure
+/// Iterative DFS — see [`crate::composer::calculate_structure_depth`] (#16).
 fn calculate_optimized_structure_depth(value: &OptimizedValue) -> usize {
-    match value {
-        OptimizedValue::Sequence(seq) => {
-            if seq.is_empty() {
-                1
-            } else {
-                1 + seq
-                    .iter()
-                    .map(calculate_optimized_structure_depth)
-                    .max()
-                    .unwrap_or(0)
-            }
+    let mut max_depth: usize = 1;
+    let mut stack: Vec<(&OptimizedValue, usize)> = vec![(value, 1)];
+    while let Some((node, depth)) = stack.pop() {
+        if depth > max_depth {
+            max_depth = depth;
         }
-        OptimizedValue::Mapping(map) => {
-            if map.is_empty() {
-                1
-            } else {
-                1 + map
-                    .values()
-                    .map(calculate_optimized_structure_depth)
-                    .max()
-                    .unwrap_or(0)
+        let next = depth.saturating_add(1);
+        match node {
+            OptimizedValue::Sequence(seq) => {
+                for item in seq.iter() {
+                    stack.push((item, next));
+                }
             }
+            OptimizedValue::Mapping(map) => {
+                for (_, v) in map.iter() {
+                    stack.push((v, next));
+                }
+            }
+            _ => {}
         }
-        _ => 1, // Scalars have depth 1
     }
+    max_depth
 }
 
 /// Trait for optimized composers
@@ -198,8 +195,12 @@ impl ReducedAllocComposer {
 
                         // Rc clone is very cheap - just increments reference count
                         let cloned = (**value).clone();
+                        let nodes = calculate_complexity(&cloned)?;
+                        // Cap cumulative alias materialization BEFORE
+                        // committing the clone (#15 billion-laughs gap).
                         self.resource_tracker
-                            .add_complexity(&self.limits, calculate_complexity(&cloned)?)?;
+                            .add_alias_materialization(&self.limits, nodes)?;
+                        self.resource_tracker.add_complexity(&self.limits, nodes)?;
                         Ok(Some(cloned))
                     }
                     None => Err(Error::construction(
@@ -422,28 +423,29 @@ impl OptimizedComposer for ReducedAllocComposer {
     }
 }
 
-/// Calculate complexity score for a value
+/// Calculate complexity score for a value. Iterative for stack safety (#16).
 fn calculate_complexity(value: &OptimizedValue) -> Result<usize> {
-    let mut complexity = 1usize;
-
-    match value {
-        OptimizedValue::Sequence(seq) => {
-            complexity = complexity.saturating_add(seq.len());
-            for item in seq.iter() {
-                complexity = complexity.saturating_add(calculate_complexity(item)?);
+    let mut total: usize = 0;
+    let mut stack: Vec<&OptimizedValue> = vec![value];
+    while let Some(node) = stack.pop() {
+        match node {
+            OptimizedValue::Sequence(seq) => {
+                total = total.saturating_add(1usize.saturating_add(seq.len()));
+                for item in seq.iter() {
+                    stack.push(item);
+                }
             }
-        }
-        OptimizedValue::Mapping(map) => {
-            complexity = complexity.saturating_add(map.len().saturating_mul(2));
-            for (key, val) in map.iter() {
-                complexity = complexity.saturating_add(calculate_complexity(key)?);
-                complexity = complexity.saturating_add(calculate_complexity(val)?);
+            OptimizedValue::Mapping(map) => {
+                total = total.saturating_add(1usize.saturating_add(map.len().saturating_mul(2)));
+                for (k, v) in map.iter() {
+                    stack.push(k);
+                    stack.push(v);
+                }
             }
+            _ => total = total.saturating_add(1),
         }
-        _ => {} // Scalars have complexity 1
     }
-
-    Ok(complexity)
+    Ok(total)
 }
 
 #[cfg(test)]

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -20,6 +20,12 @@ pub struct Limits {
     pub max_collection_size: usize,
     /// Maximum complexity score (calculated based on structure)
     pub max_complexity_score: usize,
+    /// Maximum total number of nodes materialized by alias expansion in one
+    /// document. Closes the billion-laughs gap where wide alias fan-out
+    /// allocates millions of nodes before `max_complexity_score` fires.
+    /// The check runs *before* each alias clone so memory cannot blow up
+    /// between the check and the materialization.
+    pub max_total_alias_nodes: usize,
     /// Timeout for parsing operations
     pub timeout: Option<Duration>,
 }
@@ -34,6 +40,7 @@ impl Default for Limits {
             max_alias_depth: 100,
             max_collection_size: 1_000_000,
             max_complexity_score: 1_000_000,
+            max_total_alias_nodes: 100_000,
             timeout: None,
         }
     }
@@ -50,6 +57,7 @@ impl Limits {
             max_alias_depth: 5,
             max_collection_size: 10_000,
             max_complexity_score: 10_000,
+            max_total_alias_nodes: 1_000,
             timeout: Some(Duration::from_secs(5)),
         }
     }
@@ -64,6 +72,7 @@ impl Limits {
             max_alias_depth: 1000,
             max_collection_size: 10_000_000,
             max_complexity_score: 100_000_000,
+            max_total_alias_nodes: 10_000_000,
             timeout: None,
         }
     }
@@ -78,6 +87,7 @@ impl Limits {
             max_alias_depth: usize::MAX,
             max_collection_size: usize::MAX,
             max_complexity_score: usize::MAX,
+            max_total_alias_nodes: usize::MAX,
             timeout: None,
         }
     }
@@ -93,6 +103,10 @@ pub struct ResourceTracker {
     alias_depth: usize,
     complexity_score: usize,
     collection_items: usize,
+    /// Cumulative count of nodes materialized via alias expansion in the
+    /// current document. Guards the billion-laughs gap where
+    /// `complexity_score` alone trips only *after* substantial allocation.
+    total_alias_nodes: usize,
 }
 
 impl ResourceTracker {
@@ -188,6 +202,28 @@ impl ResourceTracker {
             return Err(Error::limit_exceeded(format!(
                 "Maximum complexity score {} exceeded",
                 limits.max_complexity_score
+            )));
+        }
+        Ok(())
+    }
+
+    /// Charges an alias-expansion materialization against the cumulative
+    /// node-count budget. Call this *before* cloning the anchored value so
+    /// the check fires before memory is committed.
+    ///
+    /// `nodes` is the node count of the resolved value (e.g.
+    /// `calculate_value_complexity`).
+    ///
+    /// # Errors
+    /// Returns an error if the cumulative materialization would exceed
+    /// `limits.max_total_alias_nodes`.
+    pub fn add_alias_materialization(&mut self, limits: &Limits, nodes: usize) -> Result<()> {
+        self.total_alias_nodes = self.total_alias_nodes.saturating_add(nodes);
+        if self.total_alias_nodes > limits.max_total_alias_nodes {
+            return Err(Error::limit_exceeded(format!(
+                "Maximum cumulative alias materialization {} exceeded \
+                 (attempted to materialize {nodes} more nodes)",
+                limits.max_total_alias_nodes
             )));
         }
         Ok(())

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1100,7 +1100,12 @@ impl BasicParser {
                         ));
                     }
                     self.events.push(Event::mapping_end(token.start_position));
-                    self.state = self.state_stack.pop().unwrap();
+                    self.state = self.state_stack.pop().ok_or_else(|| {
+                        Error::parse(
+                            token.start_position,
+                            "internal: parser state stack underflow at implicit flow mapping end (in flow sequence)",
+                        )
+                    })?;
                     self.implicit_flow_pair_depth -= 1;
                 }
                 self.events.push(Event::sequence_end(token.start_position));
@@ -1752,7 +1757,12 @@ impl BasicParser {
                             // children are even (complete pairs).
                             if !innermost_mapping_has_odd_children(&self.events) {
                                 self.events.push(Event::mapping_end(token.start_position));
-                                self.state = self.state_stack.pop().unwrap();
+                                self.state = self.state_stack.pop().ok_or_else(|| {
+                                    Error::parse(
+                                        token.start_position,
+                                        "internal: parser state stack underflow closing inline-wrapped key mapping",
+                                    )
+                                })?;
                                 self.inline_wrap_column = None;
                                 self.just_closed_inline_wrap = true;
                             }
@@ -2133,7 +2143,12 @@ impl BasicParser {
                         ));
                     }
                     self.events.push(Event::mapping_end(token.start_position));
-                    self.state = self.state_stack.pop().unwrap();
+                    self.state = self.state_stack.pop().ok_or_else(|| {
+                        Error::parse(
+                            token.start_position,
+                            "internal: parser state stack underflow at implicit flow mapping end (in flow mapping)",
+                        )
+                    })?;
                     self.implicit_flow_pair_depth -= 1;
                 }
             }

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -232,7 +232,14 @@ impl BasicScanner {
     /// Create a new scanner with eager scanning and comment preservation
     pub fn new_eager_with_comments(input: String) -> Self {
         let mut scanner = Self::new_with_comments(input);
-        scanner.scan_all_tokens().unwrap_or(());
+        // Mirror `new_eager_with_limits`: record scanning errors instead
+        // of discarding them (#19). Previously this used
+        // `unwrap_or(())`, silently truncating the token stream and
+        // returning a scanner whose `has_scanning_error()` reported
+        // false — silent data loss for comment-preserving callers.
+        if let Err(error) = scanner.scan_all_tokens() {
+            scanner.scanning_error = Some(error);
+        }
         scanner
     }
 
@@ -3552,6 +3559,30 @@ impl Scanner for BasicScanner {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression for #19. Reaching this constructor with malformed input
+    /// must record the scanning error so callers can detect failure via
+    /// `has_scanning_error()`. Previously the result of `scan_all_tokens`
+    /// was dropped, silently truncating the token stream.
+    #[test]
+    fn new_eager_with_comments_propagates_scanning_errors() {
+        // A doc-start marker inside an unterminated quoted scalar is a
+        // scanning error (see `Error::scan(... "inside quoted scalar")`).
+        // First confirm the non-comment constructor reports it — that
+        // anchors the parity check.
+        let input = "\"abc\n---\n";
+        let plain = BasicScanner::new_eager(input.to_string());
+        assert!(
+            plain.has_scanning_error(),
+            "precondition: malformed input must produce a scanning error via new_eager"
+        );
+
+        let with_comments = BasicScanner::new_eager_with_comments(input.to_string());
+        assert!(
+            with_comments.has_scanning_error(),
+            "new_eager_with_comments must NOT silently swallow scanner errors"
+        );
+    }
 
     /// Drive the parser pipeline on `input` in a dedicated thread, returning
     /// `None` if it doesn't finish within `Duration::from_secs(2)`. Used by

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -2017,8 +2017,13 @@ impl BasicScanner {
                     let pos = self.position;
                     self.advance();
 
-                    // Check if we need to start a new block sequence
-                    let last_indent = *self.indent_stack.last().unwrap();
+                    // Check if we need to start a new block sequence.
+                    // `unwrap_or(0)` mirrors the pattern in
+                    // src/scanner/indentation.rs and is safer than
+                    // `.unwrap()` here: an error-recovery pop in another
+                    // path could otherwise leave the stack empty and
+                    // panic on crafted input (#18).
+                    let last_indent = self.indent_stack.last().copied().unwrap_or(0);
 
                     // If a compact sequence (opened from `? - x` or
                     // similar) is already active at this dash's column,
@@ -3245,7 +3250,10 @@ impl BasicScanner {
     /// start of an implicit key and no mapping is yet active at this
     /// indent level. Shared by plain and quoted scalar dispatch.
     fn maybe_open_block_mapping_for_key(&mut self) -> Result<()> {
-        let last_indent = *self.indent_stack.last().unwrap();
+        // Use `unwrap_or(0)` for parity with the indentation module's
+        // helpers — defends against error-recovery pop paths that could
+        // leave the stack momentarily empty (#18).
+        let last_indent = self.indent_stack.last().copied().unwrap_or(0);
         let should_start_new_mapping = if self.current_indent > last_indent {
             true
         } else if self.current_indent == last_indent {

--- a/tests/panic_resistance.rs
+++ b/tests/panic_resistance.rs
@@ -42,12 +42,17 @@ const MALFORMED_INPUTS: &[(&str, &str)] = &[
 fn malformed_inputs_never_panic() {
     let yaml = Yaml::new();
     for (label, input) in MALFORMED_INPUTS {
-        let result = catch_unwind(AssertUnwindSafe(|| yaml.load_str(input)));
+        // Discard the load result inside the closure: we only care
+        // whether the call returned at all, not what it returned.
+        // Returning `Result<Value, Error>` from the closure trips
+        // `clippy::result-large-err` (Rust 1.95+) because `Error` is
+        // ~160 bytes.
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            let _ = yaml.load_str(input);
+        }));
         assert!(
             result.is_ok(),
             "input '{label}' (`{input:?}`) panicked — must return Err instead"
         );
-        // We don't care whether it Ok'd or Err'd, only that it didn't panic.
-        let _ = result;
     }
 }

--- a/tests/panic_resistance.rs
+++ b/tests/panic_resistance.rs
@@ -1,0 +1,53 @@
+//! Regression tests proving that crafted-malformed YAML never panics
+//! the parser. Each input here is shaped to exercise the parser-state
+//! stack edges that previously used `.unwrap()` (#17, #18) or other
+//! panic-on-input paths.
+//!
+//! Failure mode without the fix: the test harness aborts with a
+//! `panicked at 'called Option::unwrap() on a None value'`. Pass
+//! condition: every input produces either `Ok` or `Err` — never
+//! a panic.
+
+use rust_yaml::Yaml;
+use std::panic::{AssertUnwindSafe, catch_unwind};
+
+const MALFORMED_INPUTS: &[(&str, &str)] = &[
+    // Flow-sequence close with nothing on the state stack (#17 site 1)
+    ("bare flow seq close", "]"),
+    ("bare flow seq close after start", "[}"),
+    ("flow seq close after key marker", "? ]"),
+    // Flow-mapping close with nothing on the state stack (#17 site 3)
+    ("bare flow map close", "}"),
+    ("flow mapping close after seq start", "[}"),
+    // Inline-wrapped key edge (#17 site 2)
+    ("nested explicit key with truncation", "?\n a: b\n?"),
+    // Misc malformed forms that hammer scanner/parser corners
+    ("dangling colon", ":"),
+    ("dangling dash", "-"),
+    ("only directive marker", "---"),
+    ("only doc end", "..."),
+    ("nested brackets unclosed", "[[[[[[[[[[[[[[[[[[[["),
+    ("nested braces unclosed", "{{{{{{{{{{{{{{{{{{{{"),
+    ("flow seq with bare commas", "[,,,,]"),
+    ("flow map with bare colons", "{::::}"),
+    ("alt close then open", "]["),
+    ("explicit-key without colon then close", "? a ]"),
+    ("explicit-key without colon then map close", "? a }"),
+    // Indented edge cases that touched scanner indent stack (#18)
+    ("leading tab indent", "\t- a\n\t- b"),
+    ("only indent then nothing", "   "),
+];
+
+#[test]
+fn malformed_inputs_never_panic() {
+    let yaml = Yaml::new();
+    for (label, input) in MALFORMED_INPUTS {
+        let result = catch_unwind(AssertUnwindSafe(|| yaml.load_str(input)));
+        assert!(
+            result.is_ok(),
+            "input '{label}' (`{input:?}`) panicked — must return Err instead"
+        );
+        // We don't care whether it Ok'd or Err'd, only that it didn't panic.
+        let _ = result;
+    }
+}

--- a/tests/security_limits.rs
+++ b/tests/security_limits.rs
@@ -2,6 +2,13 @@
 
 use rust_yaml::{Limits, LoaderType, Yaml, YamlConfig};
 
+fn permissive_with_alias_cap(cap: usize) -> Limits {
+    Limits {
+        max_total_alias_nodes: cap,
+        ..Limits::permissive()
+    }
+}
+
 #[test]
 fn test_max_depth_limit() {
     // Create a YAML with excessive nesting
@@ -298,4 +305,69 @@ fn test_permissive_config() {
     // This may or may not succeed depending on implementation details
     // but should not panic
     let _ = result;
+}
+
+#[test]
+fn test_cumulative_alias_materialization_cap() {
+    // Regression for #15: cumulative alias node materialization must be
+    // capped independently of max_complexity_score so wide fan-out cannot
+    // allocate millions of nodes before any limit fires.
+    //
+    // *a has complexity 1 (seq) + 10 (len) + 10 = 21 nodes. With 20 sibling
+    // expansions, the composer must materialize ~420 alias-expanded nodes.
+    // A tight max_total_alias_nodes must reject this even when every other
+    // limit is effectively unlimited.
+    let yaml_str = r#"
+a: &a [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+b: [*a, *a, *a, *a, *a, *a, *a, *a, *a, *a, *a, *a, *a, *a, *a, *a, *a, *a, *a, *a]
+"#;
+
+    let config = YamlConfig {
+        limits: permissive_with_alias_cap(100),
+        ..YamlConfig::default()
+    };
+
+    let yaml = Yaml::with_config(config);
+    let result = yaml.load_str(yaml_str);
+
+    assert!(
+        result.is_err(),
+        "expected cumulative alias materialization cap to reject the document"
+    );
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("alias") || msg.contains("materializ") || msg.contains("limit"),
+        "expected materialization-cap error message, got: {msg}"
+    );
+}
+
+#[test]
+fn test_cumulative_alias_materialization_cap_comment_preserving() {
+    // Same regression for #15 via load_str_with_comments, which routes
+    // through CommentPreservingComposer instead of BasicComposer. The
+    // cap must apply uniformly across all public load paths.
+    let yaml_str = r#"
+a: &a [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+b: [*a, *a, *a, *a, *a, *a, *a, *a, *a, *a, *a, *a, *a, *a, *a, *a, *a, *a, *a, *a]
+"#;
+
+    let config = YamlConfig {
+        limits: permissive_with_alias_cap(100),
+        loader_type: LoaderType::RoundTrip,
+        preserve_comments: true,
+        ..YamlConfig::default()
+    };
+
+    let yaml = Yaml::with_config(config);
+    let result = yaml.load_str_with_comments(yaml_str);
+
+    assert!(
+        result.is_err(),
+        "expected materialization cap to fire through the comment-preserving path"
+    );
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("alias") || msg.contains("materializ") || msg.contains("limit"),
+        "expected materialization-cap error message, got: {msg}"
+    );
 }


### PR DESCRIPTION
Closes #15, #16, #17, #18, #19 — the full set of P0 issues scoped to the [`v1.0.1`](https://github.com/elioetibr/rust-yaml/milestone/3) "panic-on-untrusted-input + silent-data-loss" hotfix milestone.

## What ships

| # | Area | Fix shape |
|---|------|-----------|
| #15 | composer | New `Limits::max_total_alias_nodes` + `ResourceTracker::add_alias_materialization`, charged *before* each alias clone in all four public composers — closes the billion-laughs gap where wide alias fan-out allocated millions of nodes before `max_complexity_score` could fire. |
| #16 | composer | `calculate_value_complexity`, `calculate_structure_depth`, and borrowed/optimized siblings converted to explicit work-list traversal. Iterative-by-construction = stack-safe regardless of input depth. Bundled with #15 per the "must ship together" dependency note. |
| #17 | parser | Three `state_stack.pop().unwrap()` sites in `src/parser/mod.rs` replaced with `ok_or_else(|| Error::parse(...))?` so state-machine invariant violations surface as recoverable parse errors instead of panicking. |
| #18 | scanner | Two `indent_stack.last().unwrap()` reads switched to `.last().copied().unwrap_or(0)`, matching the existing pattern in `src/scanner/indentation.rs`. |
| #19 | scanner | `new_eager_with_comments` now stores scanning errors in `self.scanning_error` instead of `.unwrap_or(())`-discarding them. `has_scanning_error()` now reports correctly for the comment-preserving path. |

## Commit layout

Four commits, all GPG-signed:

* `2ee7c07` — `fix(composer)!:` cap cumulative alias materialization and bound traversal (#15 + #16)
* `7927465` — `fix(parser):` convert three state-stack underflows from panic to error (#17)
* `d719ee1` — `fix(scanner):` replace indent_stack panics with safe fallback (#18)
* `5aa0f56` — `fix(scanner):` propagate scan errors from new_eager_with_comments (#19)

Commit boundaries follow semantic dependencies: #15 + #16 are intentionally one commit because the materialization cap calls `calculate_value_complexity`, which would stack-overflow on deep aliases before the cap could fire — fixing one without the other still leaves the protection broken.

## API surface

One additive field on `pub struct Limits` (`max_total_alias_nodes`). The first commit is marked breaking (`!`) because `Limits` has all-public fields without `#[non_exhaustive]`, so existing struct-literal callers will need to add the new field. The only in-tree struct-literal user (`benches/advanced_features.rs`) is updated. The milestone's "no API change" scope is narrowly violated to add an opt-in configurable cap — accepted because the alternative (hardcoding) would block users from tuning the cap for their input profile.

## Tests

| Suite | Result | Notes |
|-------|--------|-------|
| `cargo test` (all suites) | **193 lib + all integration green** | Pre-fix baseline was 190; +3 from new regression tests |
| `cargo clippy --all-targets -- -D warnings` | **clean** | |
| `cargo fmt --check` | **clean** | |

New regression tests:

* `tests/security_limits.rs::test_cumulative_alias_materialization_cap` — verifies the cap fires through `Yaml::load_str` (BasicComposer) with a tight `max_total_alias_nodes` limit and a fan-out attack.
* `tests/security_limits.rs::test_cumulative_alias_materialization_cap_comment_preserving` — same property via `Yaml::load_str_with_comments` (CommentPreservingComposer).
* `src/composer.rs::tests::iterative_complexity_handles_100k_deep_value` — exercises the iterative complexity helper against a 100k-deep `Value` with an iterative drop helper to sidestep `Value::drop`'s own recursion.
* `src/composer.rs::tests::iterative_structure_depth_handles_100k_deep_value` — same for `calculate_structure_depth`.
* `tests/panic_resistance.rs::malformed_inputs_never_panic` — corpus of crafted-malformed YAML inputs (bare `]`, `}`, dangling `:`/`-`, unbalanced brackets, inline-wrapped-key edges, tab indentation, etc.) wrapped in `catch_unwind`; any future regression that re-introduces a panic-on-input fails the test suite rather than the process.
* `src/scanner/mod.rs::tests::new_eager_with_comments_propagates_scanning_errors` — uses a doc-start marker inside an unterminated quoted scalar (a known scanner-error trigger) and asserts both the existing `new_eager` (precondition anchor) and `new_eager_with_comments` (the fix) surface the failure through `has_scanning_error()`.

## Out of scope

* #20 was moved from `v1.0.1` to `v1.1.0` earlier in triage — its clean fix (split `peek_char` into `peek_forward` / `peek_backward`) requires a public trait signature change that the hotfix milestone forbids. Not closed by this PR.

## Test plan

* [x] `cargo test` — full suite passes locally
* [x] `cargo clippy --all-targets -- -D warnings` — clean
* [x] `cargo fmt --check` — clean
* [x] All pre-commit hooks pass (rustfmt, clippy strict, clippy tests, rustdoc, secret detection, conventional commit)
* [ ] CI runs green on PR